### PR TITLE
trim whitespace from xlsx to json and provides log message

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -23,6 +23,14 @@ const ROCrate = rocrate.ROCrate;
 const path = require('path');
 const fs = require("fs-extra");
 
+function addWorkbookMessages(statusMessage, workbook) {
+    if (!workbook || !workbook.log || !workbook.log.info) {
+        return;
+    }
+    const trimMessages = workbook.log.info.filter(message => message.startsWith("Trimmed whitespace from "));
+    statusMessage.push(...trimMessages);
+}
+
 function addToGraph(crate, items ) {
     for (let k of Object.keys(items)) {
         const item = items[k];
@@ -79,6 +87,7 @@ async function update(dir, depth, fromJSON, existingCrate) {
         }
         const wb = new Workbook({crate: sourceCrate});
         await wb.loadExcel(additionalMetadataPath, true);
+        addWorkbookMessages(statusMessage, wb);
         sourceCrate = wb.crate;
 
     } else if (!fromJSON && await fs.pathExists(catalogPath)){
@@ -86,6 +95,7 @@ async function update(dir, depth, fromJSON, existingCrate) {
         // We have a  spreadsheet
         const wb = new Workbook();
         await wb.loadExcel(catalogPath);
+        addWorkbookMessages(statusMessage, wb);
         console.log("Loaded spreadsheet: " + catalogPath);
         // Start with a crate from a spreadsheet
         sourceCrate = wb.crate;

--- a/lib/workbook.js
+++ b/lib/workbook.js
@@ -342,7 +342,14 @@ class Workbook {
         if (!cellString) {
             return "";
         }
-        cellString = cellString.toString();
+        const originalCellString = cellString.toString();
+        const trimmedCellString = originalCellString.trim();
+        if (trimmedCellString !== originalCellString) {
+            const sheetName = val?.worksheet?.name || "unknown sheet";
+            const cellAddress = val?.address || "unknown cell";
+            this.log.info.push(`Trimmed whitespace from ${sheetName}!${cellAddress}: ${JSON.stringify(originalCellString)} -> ${JSON.stringify(trimmedCellString)}`);
+        }
+        cellString = trimmedCellString;
         const curly = cellString.match(/{(.*)}/);
         if (curly) {
             try {

--- a/rocxl
+++ b/rocxl
@@ -93,7 +93,10 @@ async function main() {
 
 
 async function processDirectory(dir, depth) {
-  await update(dir, depth, opts.JSON, opts.add);
+  const statusMessage = await update(dir, depth, opts.JSON, opts.add);
+  for (let message of statusMessage) {
+    console.log(message);
+  }
 }
 
 

--- a/test/workbook.spec.js
+++ b/test/workbook.spec.js
@@ -79,6 +79,22 @@ describe("Create a workbook from a crate", function () {
 
     });
 
+    it("Should trim whitespace when converting cells to json", async function () {
+        const c = new ROCrate({array: true, link: true});
+        const workbook = new Workbook({crate: c});
+        const sheet = workbook.workbook.addWorksheet("RootDataset");
+        sheet.columns = [
+            {header: "Name", key: "Name", width: 10},
+            {header: "Value", key: "Value", width: 100}
+        ];
+        sheet.addRow({Name: "name", Value: "  Trimmed title  "});
+
+        const item = workbook.sheetToItem("RootDataset");
+
+        assert.equal(item.item.name[0], "Trimmed title");
+        assert(workbook.log.info.some(message => message.includes("Trimmed whitespace from RootDataset!B2")));
+    });
+
 
     it("Should create a workbook with two sheets", async function () {
         this.timeout(5000);


### PR DESCRIPTION
Excel file remains the same but json output has leading and trailing spaces removed. Change message provided as the script is run:

E.g.
Trimmed whitespace from Files!AH6: "testing " -> "testing"

Unit test added.